### PR TITLE
Update recommended surveillance tag to follow OSM wiki

### DIFF
--- a/webapp/src/components/OSMTagSelector.vue
+++ b/webapp/src/components/OSMTagSelector.vue
@@ -37,7 +37,7 @@
         surveillance:type=ALPR<br>
         camera:mount=pole<br>
         camera:type=fixed<br>
-        surveillance=traffic<br>
+        surveillance=public<br>
         surveillance:zone=traffic<br>
         brand=<span class="highlight">{{ selectedBrand.name }}</span><br>
         brand:wikidata=<span class="highlight">{{ selectedBrand.wikidata }}</span><br>


### PR DESCRIPTION
"surveillance=traffic" is listed under [Possible Tagging Mistakes](https://wiki.openstreetmap.org/wiki/Key:surveillance?uselang=en#Possible_tagging_mistakes) on the wiki